### PR TITLE
Add escapejs everywhere it needed

### DIFF
--- a/anytask/courses/templates/course_tasks_many_task_many_group.html
+++ b/anytask/courses/templates/course_tasks_many_task_many_group.html
@@ -88,7 +88,7 @@
 							{% if task.is_shown %}
 								<th align="center" class="{sorter: false} no-font-weight">
 									{% if task.task_text or task.can_score %}
-										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
 											{{ task.title }}
 										</a>
 									{% else %}
@@ -116,7 +116,7 @@
 								{% if task.is_shown %}
 									<td align="center" class="student_{{ student.id }}">
 											{% if not task.is_hidden and task.can_score %}
-												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
+												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
 													<span class="label {% if task_x_task_takens|score:task %} {% if task_x_task_takens|score:task == task.score_max %} label-success {% else %} label-info {% endif %} {% endif %}">{{ task_x_task_takens|score:task }}</span>
 												</a>
 											{% elif user.username == student.username and task.can_pass %}
@@ -171,7 +171,7 @@
     							{% if task.is_shown %}
     								<th align="center" class="{sorter: false} no-font-weight">
     									{% if task.task_text or task.can_score %}
-    										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+    										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
     											{{ task.title }}
     										</a>
     									{% else %}
@@ -199,7 +199,7 @@
     								{% if task.is_shown %}
     									<td align="center">
     											{% if not task.is_hidden and task.can_score %}
-    												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task}}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize }}' {% else %} '' {% endif %})">
+    												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs}}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize|escapejs }}' {% else %} '' {% endif %})">
     													<span class="label {% if task_x_task_takens|score:task %} {% if task_x_task_takens|score:task == task.score_max %} label-success {% else %} label-info {% endif %} {% endif %}">{{ task_x_task_takens|score:task}}
                                                         </span>
     												</a>
@@ -213,7 +213,7 @@
     												{% endif %}
     											{% endif %}
     											{% if task_x_task_takens|comment:task %}
-    												<a class="icon-comment" href="javascript:get_modal_comment('{{ task_x_task_takens|comment:task|sanitize }}')"></a>
+    												<a class="icon-comment" href="javascript:get_modal_comment('{{ task_x_task_takens|comment:task|sanitize|escapejs }}')"></a>
     											{% endif %}
 
                                                 {% if user.username == student.username %}

--- a/anytask/courses/templates/course_tasks_one_tasks_many_group.html
+++ b/anytask/courses/templates/course_tasks_one_tasks_many_group.html
@@ -92,7 +92,7 @@
 							{% if task.is_shown %}
 								<th align="center" class="{sorter: false} no-font-weight">
 									{% if task.task_text or task.can_score %}
-										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+										<a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
 											{{ task.title }}
 										</a>
 									{% else %}
@@ -123,7 +123,7 @@
 								{% if task.is_shown %}
 									<td align="center" class="student_{{ student.id }}">
 											{% if not task.is_hidden and task.can_score %}
-												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_taken.score }}', {{ task.score_max }}, '{{ task_taken.teacher_comments|safe|sanitize|escapejs }}');">
+												<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_taken.score }}', {{ task.score_max }}, '{{ task_taken.teacher_comments|safe|sanitize|escapejs }}');">
 													<span class="label {% if task_taken.score %} {% if task_taken.score == task.score_max %} label-success {% else %} label-info {% endif %} {% endif %}">{{ task_taken.score }}</span>
 												</a>
 											{% elif user.username == student.username and task.can_pass %}

--- a/anytask/courses/templates/course_tasks_potok.html
+++ b/anytask/courses/templates/course_tasks_potok.html
@@ -79,7 +79,7 @@
 								<span class="label label-success">{{ task.score_max }}</span>
 							{% endif %}
 							{% if task.can_score %}
-								<a class="btn-small" href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|sanitize}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'edit')">
+								<a class="btn-small" href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'edit')">
 									Редактировать задачу
 								</a>
 								<a class="btn-small" href="javascript:get_add_task_modal({{ course.id }}, null, {{ task.id }}, '{{course.can_edit}}');">
@@ -108,7 +108,7 @@
 									<div id="{{subtask.id}}"></div><font {% if subtask.is_hidden %} color="gray" {% endif %}>{{ subtask.title }}</font>
 									<span class="label label-success">{{ subtask.score_max }}</span>
 									{% if subtask.can_score %}
-										<a class="btn-small" href="javascript:get_task_modal({{subtask.id}}, '{{subtask.title}}', '{{subtask.is_hidden}}', '{{subtask.task_text|sanitize}}', '{{subtask.task_text|escapejs}}', {{subtask.score_max}}, '{{subtask.can_score}}', 'edit')">
+										<a class="btn-small" href="javascript:get_task_modal({{subtask.id}}, '{{subtask.title|escapejs}}', '{{subtask.is_hidden}}', '{{subtask.task_text|sanitize|escapejs}}', '{{subtask.task_text|escapejs}}', {{subtask.score_max}}, '{{subtask.can_score}}', 'edit')">
 											Редактировать подзадачу
 										</a>
 									{% endif %}
@@ -146,7 +146,7 @@
 														<td style="width:20%;"></td>
 														<td style="width:20%;">
 															{% if subtask.can_score %}
-																<a class="btn-small" href="javascript:get_modal({{ subtask.id }}, '{{ subtask.title }}', '{{ task_taken.user.get_full_name }}', {{ task_taken.user.id }}, 0, {{ subtask.score_max }}, '{{ task_taken.teacher_comments|sanitize }}')">Оценить</a>
+																<a class="btn-small" href="javascript:get_modal({{ subtask.id }}, '{{ subtask.title|escapejs }}', '{{ task_taken.user.get_full_name|escapejs }}', {{ task_taken.user.id }}, 0, {{ subtask.score_max }}, '{{ task_taken.teacher_comments|sanitize|escapejs }}')">Оценить</a>
 															{% endif %}
 														</td>
 													{% endif %}
@@ -154,7 +154,7 @@
 														<td style="width:10%;">
 															<span class="label {% if task_taken.score == subtask.score_max %} label-success{% endif %}">{{ task_taken.score }}</span>
 															{% if task_taken.teacher_comments %}
-																<a class="icon-comment" href="javascript:get_modal_comment('{{ task_taken.teacher_comments|sanitize }}')"></a>
+																<a class="icon-comment" href="javascript:get_modal_comment('{{ task_taken.teacher_comments|sanitize|escapejs }}')"></a>
 															{% endif %}
 														</td>
 														<td style="width:20%;">
@@ -162,7 +162,7 @@
 														</td>
 														<td style="width:20%;">
 															{% if subtask.can_score %}
-																<a class="btn-small" href="javascript:get_modal({{ subtask.id }}, '{{ subtask.title }}', '{{ task_taken.user.get_full_name }}', {{ task_taken.user.id }}, '{{ task_taken.score }}', {{ subtask.score_max }}, '{{ task_taken.teacher_comments|sanitize }}')">Оценить</a>
+																<a class="btn-small" href="javascript:get_modal({{ subtask.id }}, '{{ subtask.title|escapejs }}', '{{ task_taken.user.get_full_name|escapejs }}', {{ task_taken.user.id }}, '{{ task_taken.score }}', {{ subtask.score_max }}, '{{ task_taken.teacher_comments|sanitize|escapejs }}')">Оценить</a>
 															{% endif %}
 														</td>
 													{% endif %}
@@ -193,7 +193,7 @@
 												<td style="width:20%;"></td>
 												<td style="width:20%;">
 													{% if task.can_score %}
-														<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ task_taken.user.get_full_name }}', {{ task_taken.user.id }}, 0, {{ task.score_max }}, '{{ task_taken.teacher_comments|sanitize }}')">Оценить</a>
+														<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ task_taken.user.get_full_name|escapejs }}', {{ task_taken.user.id }}, 0, {{ task.score_max }}, '{{ task_taken.teacher_comments|sanitize|escapejs }}')">Оценить</a>
 													{% endif %}
 												</td>
 											{% endif %}
@@ -202,7 +202,7 @@
 												<td style="width:10%;">
 													<span class="label {% if task_taken.score == task.score_max %} label-success{% endif %}">{{ task_taken.score|floatformat }}</span>
 													{% if task_taken.teacher_comments %}
-														<a class="icon-comment" href="javascript:get_modal_comment('{{ task_taken.teacher_comments|sanitize }}')"></a>
+														<a class="icon-comment" href="javascript:get_modal_comment('{{ task_taken.teacher_comments|sanitize|escapejs }}')"></a>
 													{% endif %}
 												</td>
 												<td style="width:20%;">
@@ -210,7 +210,7 @@
 												</td>
 												<td style="width:20%;">
 													{% if task.can_score %}
-														<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ task_taken.user.get_full_name }}', {{ task_taken.user.id }}, '{{ task_taken.score }}', {{ task.score_max }}, '{{ task_taken.teacher_comments|sanitize }}')">Оценить</a>
+														<a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ task_taken.user.get_full_name|escapejs }}', {{ task_taken.user.id }}, '{{ task_taken.score }}', {{ task.score_max }}, '{{ task_taken.teacher_comments|sanitize|escapejs }}')">Оценить</a>
 													{% endif %}
 												</td>
 											{% endif %}

--- a/anytask/courses/templates/course_transcript_many_task_many_group.html
+++ b/anytask/courses/templates/course_transcript_many_task_many_group.html
@@ -30,7 +30,7 @@
                             {% if task.is_shown %}
                                 <th align="center" class="{sorter: false} no-font-weight">
                                     {% if task.task_text or task.can_score %}
-                                        <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+                                        <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
                                             {{ task.title }}
                                         </a>
                                     {% else %}
@@ -58,7 +58,7 @@
                                 {% if task.is_shown %}
                                     <td align="center" class="student_{{ student.id }}">
                                             {% if not task.is_hidden and task.can_score and task_x_task_takens|get_task_taken:task|in_queue %}
-                                                <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
+                                                <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
                                                     <span class="label" style="background-color:{{ task_x_task_takens|get_task_taken:task|color_label_in_teacher_queue:color_set }}"
                                                     name="teacher_{{task_x_task_takens|get_task_taken:task|get_teacher}}"
                                                     >{{ task_x_task_takens|score:task }}</span>
@@ -96,7 +96,7 @@
                                 {% if task.is_shown %}
                                     <th align="center" class="{sorter: false} no-font-weight">
                                         {% if task.task_text or task.can_score %}
-                                            <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+                                            <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
                                                 {{ task.title }}
                                             </a>
                                         {% else %}
@@ -124,7 +124,7 @@
                                     {% if task.is_shown %}
                                         <td align="center">
                                                 {% if not task.is_hidden and task.can_score and task_x_task_takens|get_task_taken:task|in_queue %}
-                                                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task }}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize }}' {% else %} '' {% endif %})">
+                                                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs }}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize|escapejs }}' {% else %} '' {% endif %})">
                                                         <span class="label" style="background-color:{{ task_x_task_takens|get_task_taken:task|color_label_in_teacher_queue:color_set }}" name="teacher_{{task_x_task_takens|get_task_taken:task|get_teacher}}"
                                                         >{{ task_x_task_takens|score:task }}</span>
                                                     </a>

--- a/anytask/courses/templates/courses/tasklist/many_tasksets_many_groups.html
+++ b/anytask/courses/templates/courses/tasklist/many_tasksets_many_groups.html
@@ -36,7 +36,7 @@
             {% if task.is_shown %}
               <th align="center" class="{sorter: false} no-font-weight">
                 {% if task.task_text or task.can_score %}
-                  <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+                  <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
                     {{ task.title }}
                   </a>
                 {% else %}
@@ -64,7 +64,7 @@
               {% if task.is_shown %}
                 <td align="center" class="student_{{ student.id }}">
                   {% if not task.is_hidden and task.can_score %}
-                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
+                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs }}', {{ task.score_max }}, '{{ task_x_task_takens|comment:task|safe|sanitize|escapejs }}');">
                       <span class="label {% if task_x_task_takens|score:task %} {% if task_x_task_takens|score:task == task.score_max %} label-success {% else %} label-info {% endif %} {% endif %}">
                         {{ task_x_task_takens|score:task|floatformat:"-3" }}
                       </span>
@@ -129,7 +129,7 @@
             {% if task.is_shown %}
               <th align="center" class="{sorter: false} no-font-weight">
                 {% if task.task_text or task.can_score %}
-                  <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
+                  <a {% if task.is_hidden %} style="color:gray" {% endif %}  href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|safe|sanitize|escapejs}}', '{{task.task_text|safe|sanitize|escapejs}}', {{task.score_max}}, '{{task.can_score}}', 'text')">
                     {{ task.title }}
                   </a>
                 {% else %}
@@ -157,7 +157,7 @@
               {% if task.is_shown %}
                 <td align="center">
                   {% if not task.is_hidden and task.can_score %}
-                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title }}', '{{ student.get_full_name }}', {{ student.id }}, '{{ task_x_task_takens|score:task}}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize }}' {% else %} '' {% endif %})">
+                    <a class="btn-small" href="javascript:get_modal({{ task.id }}, '{{ task.title|escapejs }}', '{{ student.get_full_name|escapejs }}', {{ student.id }}, '{{ task_x_task_takens|score:task|escapejs}}', {{ task.score_max }}, {% if task_x_task_takens|comment:task %} '{{ task_x_task_takens|comment:task|sanitize|escapejs }}' {% else %} '' {% endif %})">
                       <span class="label {% if task_x_task_takens|score:task %} {% if task_x_task_takens|score:task == task.score_max %} label-success {% else %} label-info {% endif %} {% endif %}">
                         {{ task_x_task_takens|score:task}}
                       </span>
@@ -178,7 +178,7 @@
                     {% endif %}
                   {% endif %}
                   {% if task_x_task_takens|comment:task %}
-                    <a class="icon-comment" href="javascript:get_modal_comment('{{ task_x_task_takens|comment:task|sanitize }}')"></a>
+                    <a class="icon-comment" href="javascript:get_modal_comment('{{ task_x_task_takens|comment:task|sanitize|escapejs }}')"></a>
                   {% endif %}
 
                   {% if user.username == student.username %}

--- a/anytask/courses/templates/courses/tasklist/shad_cpp.html
+++ b/anytask/courses/templates/courses/tasklist/shad_cpp.html
@@ -55,7 +55,7 @@
           {% for task in group_tasks|key:group %}
             {% if not task.is_hidden or user_is_teacher %}
               <th align="center" class="{sorter: false} no-font-weight">
-                  <a {% if task.is_hidden %} style="color:gray" {% endif %} href="javascript:get_task_modal({{task.id}}, '{{task.title}}', '{{task.is_hidden}}', '{{task.task_text|urlize|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{user_is_teacher}}', 'text', {{task.contest_id}}, '{{task.problem_id}}', {% if task.group %} {{group.id}} {% else %}''{% endif %})">
+                  <a {% if task.is_hidden %} style="color:gray" {% endif %} href="javascript:get_task_modal({{task.id}}, '{{task.title|escapejs}}', '{{task.is_hidden}}', '{{task.task_text|urlize|safe|sanitize|escapejs}}', '{{task.task_text|escapejs}}', {{task.score_max}}, '{{user_is_teacher}}', 'text', {{task.contest_id}}, '{{task.problem_id}}', {% if task.group %} {{group.id}} {% else %}''{% endif %})">
                     {{ task.title }}
                   </a>
                 <span class="label {% if not task.is_hidden %} label-inverse {% endif %}">{{ task.score_max }}</span>


### PR DESCRIPTION
Чиним баг с повсеместно забытым ``escapejs``, в идеале он должен быть у вообще всех полей вставляемых в JS и руками оборачиваемых в кавычки, но я взял только те, на которые может повлиять пользователь (преподаватель или студент).

Бага критичная: 
* позволяет делать XSS
* текущий Anytask разломан везде, где я использовался символ ``'`` в комментариях

Примеры:
http://anytask.urgu.org/course/34

Невозможно посмотреть комментарии или поставить оценку Решетникову Артёму в задаче Палиндромы 