### PR TITLE
ANYTASK-442 Убрать пробелы перед "," в списке преподавателей на странице курса 

### DIFF
--- a/anytask/courses/templates/courses/gradebook.html
+++ b/anytask/courses/templates/courses/gradebook.html
@@ -69,8 +69,7 @@
                 <p class="card-text course_teachers" style="border-bottom: 1px solid #e5e5e5;">
                     {% trans "Преподаватели:" %}
                     {% for teacher in course.get_teachers %}
-                        <a href="{% url users.views.profile teacher.username %}">{{ teacher.last_name }} {{ teacher.first_name }}</a>
-                        {% if not forloop.last %},{% endif %}
+                        <a href="{% url users.views.profile teacher.username %}">{{ teacher.last_name }} {{ teacher.first_name }}</a>{% if not forloop.last %},{% endif %}
                     {% endfor %}
                 </p>
 


### PR DESCRIPTION
Перевод строки перед , браузер интерпретирует как пробел (это может показаться странным но нет, если вместо , было бы какое-нибудь слово, то возникновение пробела никого бы не удивило).