### PR TITLE
Fix Courses migration merge issue

### DIFF
--- a/anytask/courses/migrations/0039_auto__add_field_course_default_task_send_to_users.py
+++ b/anytask/courses/migrations/0039_auto__add_field_course_default_task_send_to_users.py
@@ -111,14 +111,18 @@ class Migration(SchemaMigration):
             'name_int': ('django.db.models.fields.IntegerField', [], {'default': '0'})
         },
         'courses.studentcoursemark': {
-            'Meta': {'unique_together': "(('student', 'course', 'group'),)", 'object_name': 'StudentCourseMark'},
-            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['courses.Course']", 'db_index': 'False'}),
-            'group': ('django.db.models.fields.related.ForeignKey', [], {'db_index': 'False', 'to': "orm['groups.Group']", 'null': 'True', 'blank': 'True'}),
+            'Meta': {'unique_together': "(('student', 'course'),)", 'object_name': 'StudentCourseMark'},
+            'course': (
+            'django.db.models.fields.related.ForeignKey', [], {'to': "orm['courses.Course']", 'db_index': 'False'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'mark': ('django.db.models.fields.related.ForeignKey', [], {'db_index': 'False', 'to': "orm['courses.MarkField']", 'null': 'True', 'blank': 'True'}),
+            'mark': ('django.db.models.fields.related.ForeignKey', [],
+                     {'db_index': 'False', 'to': "orm['courses.MarkField']", 'null': 'True', 'blank': 'True'}),
             'student': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"}),
-            'teacher': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'teacher_change_mark'", 'null': 'True', 'db_index': 'False', 'to': "orm['auth.User']"}),
-            'update_time': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
+            'teacher': ('django.db.models.fields.related.ForeignKey', [],
+                        {'blank': 'True', 'related_name': "'teacher_change_mark'", 'null': 'True', 'db_index': 'False',
+                         'to': "orm['auth.User']"}),
+            'update_time': ('django.db.models.fields.DateTimeField', [],
+                            {'default': 'datetime.datetime.now', 'auto_now': 'True', 'blank': 'True'})
         },
         'groups.group': {
             'Meta': {'unique_together': "(('year', 'name'),)", 'object_name': 'Group'},


### PR DESCRIPTION
Сейчас если сделать на чистой копии ./manage.py schemamigration courses --auto, то создастся миграция:

```
(anytask) [130]:20170403_08:29:12:::zhnick@zhnick-osx2:~/p/anytask_clean/anytask$ ./manage.py schemamigration courses --auto
 - Deleted field group on courses.StudentCourseMark
 - Deleted unique constraint for ['student', 'course', 'group'] on courses.StudentCourseMark
 + Added unique constraint for ['student', 'course'] on courses.StudentCourseMark
Created 0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_.py. You can now apply this migration with: ./manage.py migrate courses
(anytask) [0]:20170403_08:29:19:::zhnick@zhnick-osx2:~/p/anytask_clean/anytask$
```
Это само по себе плохо, но проблема еще в том, что она не наложится, потому что БД к этому моменту уже итак в том состоянии в которое эта миграция хочет привести:

```
(anytask) [130]:20170403_08:29:12:::zhnick@zhnick-osx2:~/p/anytask_clean/anytask$ ./manage.py schemamigration courses --auto
 - Deleted field group on courses.StudentCourseMark
 - Deleted unique constraint for ['student', 'course', 'group'] on courses.StudentCourseMark
 + Added unique constraint for ['student', 'course'] on courses.StudentCourseMark
Created 0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_.py. You can now apply this migration with: ./manage.py migrate courses
(anytask) [0]:20170403_08:29:19:::zhnick@zhnick-osx2:~/p/anytask_clean/anytask$ ./manage.py migrate courses
Running migrations for courses:
 - Migrating forwards to 0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_.
 > courses:0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_
FATAL ERROR - The following SQL query failed: CREATE UNIQUE INDEX "courses_studentcoursemark_student_id__course_id" ON "courses_studentcoursemark"("student_id", "course_id");
The error was: index courses_studentcoursemark_student_id__course_id already exists
 ! Error found during real run of migration! Aborting.

 ! Since you have a database that does not support running
 ! schema-altering statements in transactions, we have had
 ! to leave it in an interim state between migrations.

! You *might* be able to recover with:   = CREATE UNIQUE INDEX "courses_studentcoursemark_student_id__course_id__group_id" ON "courses_studentcoursemark"("student_id", "course_id", "group_id"); []

 ! The South developers regret this has happened, and would
 ! like to gently persuade you to consider a slightly
 ! easier-to-deal-with DBMS (one that supports DDL transactions)
 ! NOTE: The error which caused the migration to fail is further up.
Error in migration: courses:0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_
Traceback (most recent call last):
  File "./manage.py", line 23, in <module>
    execute_manager(settings)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/core/management/__init__.py", line 459, in execute_manager
    utility.execute()
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/core/management/__init__.py", line 382, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/core/management/base.py", line 196, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/core/management/base.py", line 232, in execute
    output = self.handle(*args, **options)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/management/commands/migrate.py", line 111, in handle
    ignore_ghosts = ignore_ghosts,
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/__init__.py", line 220, in migrate_app
    success = migrator.migrate_many(target, workplan, database)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 256, in migrate_many
    result = migrator.__class__.migrate_many(migrator, target, migrations, database)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 331, in migrate_many
    result = self.migrate(migration, database)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 133, in migrate
    result = self.run(migration, database)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 114, in run
    return self.run_migration(migration, database)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 84, in run_migration
    migration_function()
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/migration/migrators.py", line 60, in <lambda>
    return (lambda: direction(orm))
  File "/Users/zhnick/p/anytask_clean/anytask/courses/migrations/0040_auto__del_field_studentcoursemark_group__del_unique_studentcoursemark_.py", line 18, in forwards
    db.create_unique('courses_studentcoursemark', ['student_id', 'course_id'])
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/db/sqlite3.py", line 251, in create_unique
    self._create_unique(table_name, columns)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/db/sqlite3.py", line 153, in _create_unique
    self._create_index(table_name, columns, True)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/db/sqlite3.py", line 162, in _create_index
    ', '.join(self.quote_name(c) for c in columns),
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/south/db/generic.py", line 282, in execute
    cursor.execute(sql, params)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/db/backends/util.py", line 40, in execute
    return self.cursor.execute(sql, params)
  File "/Users/zhnick/venv/anytask/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py", line 344, in execute
    return Database.Cursor.execute(self, query, params)
django.db.utils.DatabaseError: index courses_studentcoursemark_student_id__course_id already exists
```

Все дело в том, что каждая миграция содержит в себе текущее состояние БД и когда кто-то делает ./manage.py schemamigration courses --auto, то сравнивается состояние в последней миграции с состоянием в models.py. И видимо просто случилась проблема мержа: текущее состояние StudentCourseMark в последней миграции на шаг назад от того, что есть на самом деле.

В этом PR я просто откатил состояние в StudentCourseMark в 39-й миграции до 38-й.
