### PR TITLE
Enlarge MAX_COMMENT_SIZE in easy_ci_robot.py

### DIFF
--- a/easyci/easy_ci_robot.py
+++ b/easyci/easy_ci_robot.py
@@ -19,7 +19,7 @@ from contextlib import contextmanager
 
 CONFIG = "config.json"
 PASSWORDS = "passwords.json"
-MAX_COMMENT_SIZE = 5000
+MAX_COMMENT_SIZE = 10000
 PROCS = 2
 REQUEST_TIMEOUT = 180
 


### PR DESCRIPTION
So that sanitizer output with stack-trace is not truncated.