### PR TITLE
Don't add "Z" to iso time

### DIFF
--- a/anytask/api/views.py
+++ b/anytask/api/views.py
@@ -73,8 +73,8 @@ def unpack_issue(issue, add_events=False, request=None, lang=settings.API_LANGUA
     ret = {
         "id": issue.id,
         "mark": issue.mark,
-        "create_time": issue.create_time.isoformat() + "Z",
-        "update_time": issue.update_time.isoformat() + "Z",
+        "create_time": issue.create_time.isoformat(),
+        "update_time": issue.update_time.isoformat(),
         "responsible": None,
         "followers": map(lambda x: unpack_user(x), issue.followers.all()),
         "status": unpack_status(issue.status_field, lang),
@@ -118,7 +118,7 @@ def has_access(user, issue):
 def unpack_event(request, event):
     ret = {
         "id": event.id,
-        "timestamp": event.timestamp.isoformat() + "Z",
+        "timestamp": event.timestamp.isoformat(),
         "author": unpack_user(event.author),
         "message": event.get_message(),
         # "files": list(event.file_set.all())


### PR DESCRIPTION
`isoformat()` already adds `+00:00` to the result, so there is no need to add `Z` which means the same. Currently API returns time in the format `2020-10-05T18:57:46+00:00Z`, which can't be parsed by `datetime.fromisoformat`.