### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/anytask.yml
+++ b/.github/workflows/anytask.yml
@@ -1,0 +1,40 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Anytask tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Set up Python 2.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 2.7
+    - name: Install dependencies
+      run: |
+        pip install pip>=9.0.1
+        pip install --upgrade flake8
+        pip install -r requirements_local.txt
+        sudo apt-get install p7zip-full tar xz-utils bzip2 gzip
+        sudo apt-get install python3
+    - name: Lint with flake8
+      run: |
+        cd anytask
+        flake8 --version
+        flake8
+    - name: Run django tests
+      run: |
+        cd anytask
+        python manage.py test

--- a/.github/workflows/anytask.yml
+++ b/.github/workflows/anytask.yml
@@ -3,11 +3,7 @@
 
 name: Anytask tests
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Сейчас триггерится на push master и pull_request master, или лучше на все ветки?

Для коммита работает:
https://github.com/bcskda/anytask/commit/5a359dcb669b689fc5a4f1705f2c88cd031ab37d
https://github.com/bcskda/anytask/actions/runs/613097119

Для PR работает:
https://github.com/bcskda/anytask/pull/1
https://github.com/bcskda/anytask/actions/runs/613102252