### PR TITLE
Pin setuptools-scm version (affected CI jobs)

### DIFF
--- a/.github/workflows/anytask.yml
+++ b/.github/workflows/anytask.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install pip>=9.0.1
-        pip install --upgrade flake8
+        pip install --upgrade flake8 'setuptools-scm==5.0.2'
         pip install -r requirements_local.txt
         sudo apt-get install p7zip-full tar xz-utils bzip2 gzip
         sudo apt-get install python3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools-scm==5.0.2     # breaks python2 support
 argparse==1.4.0           # via dateutils
 backports-abc==0.5        # via tornado
 backports.shutil-get-terminal-size==1.0.0  # via ipython

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -1,3 +1,4 @@
+setuptools-scm==5.0.2    # breaks python2 support
 tornado==4.5.3
 ipykernel==4.5.2
 django==1.11.29


### PR DESCRIPTION
В setuptools-scm-6.0.0 дропнули python-2.7

После этого [вот так](https://github.com/bcskda/anytask/actions/runs/665046132) стали падать джобы в github actions