### PR TITLE
CST-46 MinIO in local beta & Fix migrate

### DIFF
--- a/deploy_local_beta/deploy_local_beta.sh
+++ b/deploy_local_beta/deploy_local_beta.sh
@@ -31,3 +31,28 @@ then
 else
   . $ANYBETA_DEPLOY/deploy_local_beta_python3.sh
 fi
+
+# MINIO
+################
+
+if [ x"$ANYBETA_WITH_MINIO" = "x1" ]
+then
+  ANYBETA_report
+  ANYBETA_report "Pull MinIO docker image"
+  docker pull "$ANYBETA_MINIO_IMAGE"
+  ANYBETA_crash_on_error
+  ANYBETA_report "Start MinIO container"
+  docker run --rm --detach -p 9000:9000 "$ANYBETA_MINIO_IMAGE" server /data
+  sleep 5
+  ANYBETA_crash_on_error
+  ANYBETA_report "Create test bucket"
+  s3cmd --no-ssl $ANYBETA_MINIO_OPTIONS mb s3://"$ANYBETA_MINIO_BUCKET"
+  ANYBETA_crash_on_error
+fi
+
+# FINISHED
+#################
+
+ANYBETA_report
+ANYBETA_report "Deploy completed!"
+ANYBETA_report "You can now start django server using \`manage.py runserver\`"

--- a/deploy_local_beta/deploy_local_beta_python2.sh
+++ b/deploy_local_beta/deploy_local_beta_python2.sh
@@ -47,7 +47,3 @@ ANYBETA_report
 ANYBETA_report "Create test database"
 $ANYBETA_DEPLOY/generate_test_db.sh
 ANYBETA_crash_on_error
-
-ANYBETA_report
-ANYBETA_report "Deploy completed!"
-ANYBETA_report "You can now start django server using \`manage.py runserver\`"

--- a/deploy_local_beta/run.sh
+++ b/deploy_local_beta/run.sh
@@ -39,6 +39,11 @@ while (( "$#" )); do
       exit 0
       ;;
 
+    --with-minio)
+      export ANYBETA_WITH_MINIO=1
+      shift
+      ;;
+
     *)
       ANYBETA_error "Error: unknown parameter $ANYBETA_PARAM"
       exit 1

--- a/deploy_local_beta/settings.sh
+++ b/deploy_local_beta/settings.sh
@@ -16,6 +16,10 @@ export ANYBETA_VENV_NAME="anytask_venv"
 export ANYBETA_VENV_DIR="$ANYBETA_ROOT/$ANYBETA_VENV_NAME"
 export ANYBETA_VENV_ACTIVATE="$ANYBETA_VENV_DIR/bin/activate"
 
+export ANYBETA_MINIO_BUCKET="anytask-test-s3"
+export ANYBETA_MINIO_IMAGE="minio/minio:RELEASE.2021-03-17T02-33-02Z"
+export ANYBETA_MINIO_OPTIONS="--access_key minioadmin --secret_key minioadmin --host localhost:9000 --host-bucket localhost:9000"
+
 export ANYBETA_REPORT_PREFIX=">>>"
 export ANYBETA_ERROR_PREFIX="ERROR:"
 
@@ -94,6 +98,10 @@ function ANYBETA_cleanup() {
 
     unset ANYBETA_ROOT
     unset ANYBETA_DEPLOY
+    unset ANYBETA_WITH_MINIO
+    unset ANYBETA_MINIO_BUCKET
+    unset ANYBETA_MINIO_IMAGE
+    unset ANYBETA_MINIO_OPTIONS
     unset ANYBETA_PYTHON_PATH
     unset ANYBETA_VENV_NAME
     unset ANYBETA_VENV_DIR


### PR DESCRIPTION
1) Для `deploy_local_beta/run.sh` появилась опция `--with-minio`, загружающая docker-образ MinIO и запускающая в фоне контейнер.

2) Довольно часто несколько записей в БД ссылаются на один и тот же файл. В таком случае для всех записей, кроме одной, путь в БД переписывался даже с опцией `--rewrite-only-existing`. PR это исправляет складированием новых путей в set.