### PR TITLE
Upgrade Django 2.0.13 to 2.1.15 with required dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim
 
-ENV LANG C.UTF-8
-ENV LC_ALL C.UTF-8
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
 
 # Install packages needed to run your application (not build deps):
 #   mime-support -- for mime types when serving static files
@@ -43,6 +43,8 @@ RUN set -ex \
         libpq-dev \
         default-libmysqlclient-dev \
         default-mysql-client \
+        libxml2-dev \
+        libxslt1-dev \
     " \
     && apt-get update && apt-get install -y --no-install-recommends $BUILD_DEPS \
     && pip install -U virtualenv \

--- a/anytask/courses/views.py
+++ b/anytask/courses/views.py
@@ -64,7 +64,7 @@ def queue_page(request, course_id):
     if not course.user_can_see_queue(user):
         raise PermissionDenied
 
-    f = IssueFilter(request.GET, {})
+    f = IssueFilter(request.GET, Issue.objects.none())
     f.set_course(course, user)
     session_key = '_'.join([QUEUE_SESSION_PREFIX, str(course_id)])
     if request.GET:

--- a/anytask/issues/issueFilter.py
+++ b/anytask/issues/issueFilter.py
@@ -16,7 +16,9 @@ class IssueFilter(django_filters.FilterSet):
     update_time = django_filters.DateRangeFilter(label=_('data_poslednego_izmenenija'))
     responsible = django_filters.MultipleChoiceFilter(label=_('proverjaushij'), widget=forms.SelectMultiple)
     followers = django_filters.MultipleChoiceFilter(label=_('nabludateli'), widget=forms.SelectMultiple)
-    students = django_filters.MultipleChoiceFilter(field_name="student", label=_('studenty'), widget=forms.SelectMultiple)
+    students = django_filters.MultipleChoiceFilter(
+        field_name="student", label=_('studenty'), widget=forms.SelectMultiple
+    )
     seminars = django_filters.MultipleChoiceFilter(
         field_name="task__parent_task", label=_('uroki'), widget=forms.SelectMultiple
     )

--- a/anytask/issues/issueFilter.py
+++ b/anytask/issues/issueFilter.py
@@ -16,9 +16,9 @@ class IssueFilter(django_filters.FilterSet):
     update_time = django_filters.DateRangeFilter(label=_('data_poslednego_izmenenija'))
     responsible = django_filters.MultipleChoiceFilter(label=_('proverjaushij'), widget=forms.SelectMultiple)
     followers = django_filters.MultipleChoiceFilter(label=_('nabludateli'), widget=forms.SelectMultiple)
-    students = django_filters.MultipleChoiceFilter(name="student", label=_('studenty'), widget=forms.SelectMultiple)
+    students = django_filters.MultipleChoiceFilter(field_name="student", label=_('studenty'), widget=forms.SelectMultiple)
     seminars = django_filters.MultipleChoiceFilter(
-        name="task__parent_task", label=_('uroki'), widget=forms.SelectMultiple
+        field_name="task__parent_task", label=_('uroki'), widget=forms.SelectMultiple
     )
     task = django_filters.MultipleChoiceFilter(label=_('zadacha'), widget=forms.SelectMultiple)
 

--- a/anytask/issues/model_issue_student_filter.py
+++ b/anytask/issues/model_issue_student_filter.py
@@ -11,13 +11,13 @@ from issues.model_issue_status import IssueStatus
 
 
 class IssueFilterStudent(django_filters.FilterSet):
-    is_active = django_filters.ChoiceFilter(label=_('tip_kursa'), name='task__course__is_active')
+    is_active = django_filters.ChoiceFilter(label=_('tip_kursa'), field_name='task__course__is_active')
     years = django_filters.MultipleChoiceFilter(
         label=_('god_kursa'),
-        name='task__course__year',
+        field_name='task__course__year',
         widget=forms.CheckboxSelectMultiple
     )
-    courses = django_filters.MultipleChoiceFilter(label=_('kurs'), name='task__course', widget=forms.SelectMultiple)
+    courses = django_filters.MultipleChoiceFilter(label=_('kurs'), field_name='task__course', widget=forms.SelectMultiple)
     responsible = django_filters.MultipleChoiceFilter(label=_('prepodavateli'), widget=forms.SelectMultiple)
     status_field = django_filters.MultipleChoiceFilter(label=_('status'), widget=forms.SelectMultiple)
     update_time = django_filters.DateRangeFilter(label=_('data_poslednego_izmenenija'))

--- a/anytask/issues/model_issue_student_filter.py
+++ b/anytask/issues/model_issue_student_filter.py
@@ -17,7 +17,9 @@ class IssueFilterStudent(django_filters.FilterSet):
         field_name='task__course__year',
         widget=forms.CheckboxSelectMultiple
     )
-    courses = django_filters.MultipleChoiceFilter(label=_('kurs'), field_name='task__course', widget=forms.SelectMultiple)
+    courses = django_filters.MultipleChoiceFilter(
+        label=_('kurs'), field_name='task__course', widget=forms.SelectMultiple
+    )
     responsible = django_filters.MultipleChoiceFilter(label=_('prepodavateli'), widget=forms.SelectMultiple)
     status_field = django_filters.MultipleChoiceFilter(label=_('status'), widget=forms.SelectMultiple)
     update_time = django_filters.DateRangeFilter(label=_('data_poslednego_izmenenija'))

--- a/anytask/urls.py
+++ b/anytask/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     url(r'^setlanguage/', users.views.set_user_language),
     url(r'^invites/', include('invites.urls')),
     url(r'^anyrb/', include('anyrb.urls')),
-    url(r'^accounts/logout/$', django.contrib.auth.views.logout, {'next_page': '/'}),
+    url(r'^accounts/logout/$', django.contrib.auth.views.LogoutView.as_view(next_page='/'), name='logout'),
     url(r'^accounts/profile/(?P<username>.*)/(?P<year>\d+)', users.views.profile, name='users.views.profile'),
     url(r'^accounts/profile/(?P<username>.*)', users.views.profile, name='users.views.profile'),
     url(r'^accounts/profile', users.views.profile, name='users.views.profile'),

--- a/anytask/users/model_user_profile_filter.py
+++ b/anytask/users/model_user_profile_filter.py
@@ -58,7 +58,7 @@ class UserProfileFilter(django_filters.FilterSet):
         )
     '''
 
-    def empty_filter(self, qs, value):
+    def empty_filter(self, qs, name, value):
         return qs
 
     # def filter_course(self, qs, value):

--- a/anytask/users/views.py
+++ b/anytask/users/views.py
@@ -41,6 +41,7 @@ import json
 import datetime
 import pytz
 from reversion import revisions as reversion
+from reversion.models import Version
 
 
 @login_required
@@ -235,7 +236,7 @@ def profile_history(request, username=None):
         user_to_show = get_object_or_404(User, username=username)
     user_profile = user_to_show.profile
 
-    version_list = reversion.get_for_object(user_profile)
+    version_list = Version.objects.get_for_object(user_profile)
     user_status_prev = None
     history = []
     for version in reversed(version_list):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ django-crispy-forms==1.8.1
 django-debug-toolbar==1.3.2
 django-extensions==2.2.9
 django-filemanager==0.0.5
-django-filter==1.1.0
+django-filter==2.2.0
 django-haystack==2.8.1
 django-htmlmin==0.11.0
 django-dprog-jfu==2.2.3
 django-recaptcha==1.4.0
-django-reversion==2.0.13
-django==2.0.13
+django-reversion==3.0.9
+django==2.1.15
 django_premailer==0.2.0
 django-storages==1.9.1
 boto3==1.20.41

--- a/requirements_local.txt
+++ b/requirements_local.txt
@@ -1,6 +1,6 @@
 tornado==5
 ipykernel==4.5.2
-django==2.0.13
+django==2.1.15
 Pillow==9.0.0
 django-recaptcha==1.4.0
 python-gettext==3.0
@@ -17,7 +17,7 @@ requests==2.27.1
 flup==1.0.3
 text-unidecode==1.3
 django-dprog-jfu==2.2.3
-django-filter==1.1.0
+django-filter==2.2.0
 xmltodict==0.11.0
 django-crispy-forms==1.8.1
 mock==3.0.5
@@ -27,7 +27,7 @@ django-storages==1.9.1
 boto3==1.20.41
 s3cmd==2.1.0
 Whoosh==2.7.4
-django-reversion==2.0.13
+django-reversion==3.0.9
 dateutils==0.6.12
 flake8==3.8.4
 django_premailer==0.2.0


### PR DESCRIPTION
- Bump django 2.0.13 -> 2.1.15
- Bump django-reversion 2.0.13 -> 3.0.9 (2.x does not support Django 2.1)
- Bump django-filter 1.1.0 -> 2.2.0 (QUERY_TERMS removed in Django 2.1; 2.3+ requires Django 2.2+)
- Replace removed auth.views.logout with LogoutView.as_view()
- Update reversion API: get_for_object() -> Version.objects.get_for_object()
- Update django-filter: name= -> field_name=, method signature (qs, name, value)
- Fix IssueFilter instantiation to pass queryset instead of empty dict
